### PR TITLE
feat: taskに関するmock APIの作成[WIP]

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
+github.com/labstack/echo v1.4.4 h1:1bEiBNeGSUKxcPDGfZ/7IgdhJJZx8wV/pICJh4W2NJI=
+github.com/labstack/echo v3.3.10+incompatible h1:pGRcYk231ExFAyoAjAfD85kQzRJCRI8bbnE7CX5OEgg=
 github.com/labstack/echo/v4 v4.2.1 h1:LF5Iq7t/jrtUuSutNuiEWtB5eiHfZ5gSe2pcu5exjQw=
 github.com/labstack/echo/v4 v4.2.1/go.mod h1:AA49e0DZ8kk5jTOOCKNuPR6oTnBS0dYiM4FW1e6jwpg=
 github.com/labstack/gommon v0.3.0 h1:JEeO0bvc78PKdyHxloTKiF8BD5iGrH8T6MSeGvSgob0=

--- a/pkg/presentation/controller/task.go
+++ b/pkg/presentation/controller/task.go
@@ -1,0 +1,38 @@
+package controller
+
+import (
+	"log"
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+)
+
+type Task struct {
+}
+
+func NewTask() *Task {
+	return &Task{}
+}
+
+type CreateTaskRequest struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
+type mockCreateTaskResponse struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
+func (t *Task) HandleCreateTask(c echo.Context) error {
+	req := new(CreateTaskRequest)
+	if err := c.Bind(req); err != nil {
+		log.Println(err)
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid request body")
+	}
+	mockRes := &mockCreateTaskResponse{
+		Name:        req.Name,
+		Description: req.Description,
+	}
+	return c.JSON(http.StatusOK, mockRes)
+}

--- a/pkg/presentation/router.go
+++ b/pkg/presentation/router.go
@@ -13,5 +13,8 @@ func NewEcho() *echo.Echo {
 	u := controller.NewUser()
 	e.POST("/users", u.HandleCreateUser)
 	e.POST("/login", u.HandleLogin)
+
+	t := controller.NewTask()
+	e.POST("/tasks", t.HandleCreateTask)
 	return e
 }


### PR DESCRIPTION
ios側が開発しやすいようにDBを介さずに，リクエストを受け取り値を返すだけのAPIを作成しました．

`POST /tasks`

に対して，作成したtaskのnameとdescripitonをそのまま返します．