### PR TITLE
feat: task周りのAPIの実装[WIP]

### DIFF
--- a/config/dsn.go
+++ b/config/dsn.go
@@ -1,0 +1,18 @@
+package config
+
+import (
+	"fmt"
+	"os"
+)
+
+// DSN は，DSN(Data Source Name)を返します．
+func DSN() string {
+	return fmt.Sprintf(
+		"%s:%s@tcp(%s:%s)/%s",
+		os.Getenv("MYSQL_USER"),
+		os.Getenv("MYSQL_PASSWORD"),
+		os.Getenv("MYSQL_HOST"),
+		os.Getenv("MYSQL_PORT"),
+		os.Getenv("MYSQL_DATABASE"),
+	) + "?parseTime=true&collation=utf8mb4_bin"
+}

--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,5 @@ go 1.15
 require (
 	github.com/labstack/echo/v4 v4.2.1
 	golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83 // indirect
+	gorm.io/driver/mysql v1.0.5 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,12 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
+github.com/go-sql-driver/mysql v1.5.0 h1:ozyZYNQW3x3HtqT1jira07DN2PArx2v7/mN66gGcHOs=
+github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
+github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD/E=
+github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
+github.com/jinzhu/now v1.1.1 h1:g39TucaRWyV3dwDO++eEc6qf8TVIQ/Da48WmqjZ3i7E=
+github.com/jinzhu/now v1.1.1/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
 github.com/labstack/echo v1.4.4 h1:1bEiBNeGSUKxcPDGfZ/7IgdhJJZx8wV/pICJh4W2NJI=
 github.com/labstack/echo v3.3.10+incompatible h1:pGRcYk231ExFAyoAjAfD85kQzRJCRI8bbnE7CX5OEgg=
 github.com/labstack/echo/v4 v4.2.1 h1:LF5Iq7t/jrtUuSutNuiEWtB5eiHfZ5gSe2pcu5exjQw=
@@ -60,3 +66,7 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gorm.io/driver/mysql v1.0.5 h1:WAAmvLK2rG0tCOqrf5XcLi2QUwugd4rcVJ/W3aoon9o=
+gorm.io/driver/mysql v1.0.5/go.mod h1:N1OIhHAIhx5SunkMGqWbGFVeh4yTNWKmMo1GOAsohLI=
+gorm.io/gorm v1.21.3 h1:qDFi55ZOsjZTwk5eN+uhAmHi8GysJ/qCTichM/yO7ME=
+gorm.io/gorm v1.21.3/go.mod h1:0HFTzE/SqkGTzK6TlDPPQbAYCluiVvhzoA1+aVyzenw=

--- a/pkg/application/task.go
+++ b/pkg/application/task.go
@@ -1,0 +1,1 @@
+package application

--- a/pkg/application/task.go
+++ b/pkg/application/task.go
@@ -1,1 +1,33 @@
 package application
+
+import (
+	"context"
+	"github.com/ari1021/hack-ios-server/pkg/domain/model"
+	"github.com/ari1021/hack-ios-server/pkg/domain/repository"
+)
+
+type Task interface {
+	CreateTask(ctx context.Context, taskID string, taskName string, taskDesc string) (err error)
+	SelectTask(ctx context.Context, userID string) (list *[]model.Task, err error)
+}
+
+type TaskApplication struct {
+	taskRepository repository.Task
+}
+
+// NewTaskApplication はapplication.Taskを返します
+func NewTaskApplication(taskRepository repository.Task) Task {
+	return &TaskApplication{
+		taskRepository: taskRepository,
+	}
+}
+
+// CreateTaskは，taskを生成しDBにinsertします
+func (ta *TaskApplication) CreateTask(ctx context.Context, taskID string, taskName string, taskDesc string) (err error) {
+	return err
+}
+
+// SelectTaskは，userIDに紐づくtaskをリストで返します
+func (ta *TaskApplication) SelectTask(ctx context.Context, userID string) (list *[]model.Task, err error) {
+	return nil, err
+}

--- a/pkg/domain/model/task.go
+++ b/pkg/domain/model/task.go
@@ -1,0 +1,4 @@
+package model
+
+type Task struct {
+}

--- a/pkg/domain/repository/task.go
+++ b/pkg/domain/repository/task.go
@@ -1,0 +1,11 @@
+package repository
+
+import (
+	"context"
+	"github.com/ari1021/hack-ios-server/pkg/domain/model"
+)
+
+type Task interface {
+	CreateTask(ctx context.Context, taskID string, taskName string, taskDesc string) (err error)
+	SelectTask(ctx context.Context, userID string) (list *[]model.Task, err error)
+}

--- a/pkg/infrastructure/conn.go
+++ b/pkg/infrastructure/conn.go
@@ -1,0 +1,33 @@
+package infrastructure
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/ari1021/hack-ios-server/config"
+	"gorm.io/driver/mysql"
+	"gorm.io/gorm"
+)
+
+// NewConnection は，migrationを行い，*gorm.DBを返します．
+func NewConnection() (*gorm.DB, error) {
+	DSN := config.DSN()
+	conn, err := gorm.Open(mysql.Open(DSN), &gorm.Config{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to open MySQL: %w", err)
+	}
+	if err := migrate(conn); err != nil {
+		log.Fatal(err)
+	}
+	return conn, nil
+}
+
+// migrate は，migrationを行います．
+func migrate(conn *gorm.DB) error {
+	if err := conn.AutoMigrate(
+		&User{},
+	); err != nil {
+		return fmt.Errorf("failed to migrate: %w", err)
+	}
+	return nil
+}

--- a/pkg/presentation/controller/task.go
+++ b/pkg/presentation/controller/task.go
@@ -24,6 +24,17 @@ type mockCreateTaskResponse struct {
 	Description string `json:"description"`
 }
 
+type GetTaskResult struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Done        string `json:"done"`
+}
+
+type mockGetTaskResponse struct {
+	Response []GetTaskResult
+}
+
 func (t *Task) HandleCreateTask(c echo.Context) error {
 	req := new(CreateTaskRequest)
 	if err := c.Bind(req); err != nil {
@@ -34,5 +45,25 @@ func (t *Task) HandleCreateTask(c echo.Context) error {
 		Name:        req.Name,
 		Description: req.Description,
 	}
+	return c.JSON(http.StatusOK, mockRes)
+}
+
+func (t *Task) HandleGetTask(c echo.Context) error {
+	var TaskResultList []GetTaskResult
+
+	TaskResultList = append(TaskResultList, GetTaskResult{
+		ID:          "testID1",
+		Name:        "testName1",
+		Description: "testDescription1",
+	})
+	TaskResultList = append(TaskResultList, GetTaskResult{
+		ID:          "testID2",
+		Name:        "testName2",
+		Description: "testDescription2",
+	})
+	mockRes := &mockGetTaskResponse{
+		Response: TaskResultList,
+	}
+
 	return c.JSON(http.StatusOK, mockRes)
 }

--- a/pkg/presentation/router.go
+++ b/pkg/presentation/router.go
@@ -16,5 +16,6 @@ func NewEcho() *echo.Echo {
 
 	t := controller.NewTask()
 	e.POST("/tasks", t.HandleCreateTask)
+	e.GET("/tasks", t.HandleGetTask)
 	return e
 }


### PR DESCRIPTION
ios側が開発しやすいようにDBを介さずに，リクエストを受け取り値を返すだけのAPIを作成しました．

`GET /tasks
`
リクエストに対して，taskのmockリストを返します．