### PR TITLE
feat: task周りのmockAPIの追加

### DIFF
--- a/pkg/presentation/controller/task.go
+++ b/pkg/presentation/controller/task.go
@@ -28,22 +28,29 @@ type GetTaskResult struct {
 	ID          string `json:"id"`
 	Name        string `json:"name"`
 	Description string `json:"description"`
-	Done        bool   `json:"done"`
+	IsDone      bool   `json:"isDone"`
 }
 
 type mockGetTaskResponse struct {
-	Response []GetTaskResult
+	Response []*GetTaskResult
 }
 
-type TaskDoneRequest struct {
+type taskID struct {
 	ID string `json:"id"`
 }
 
-type mockTaskDoneResponse struct {
+type taskDoneRequest struct {
+	TaskIDs []*taskID `json:"taskIDs"`
+}
+
+type task struct {
 	ID          string `json:"id"`
 	Name        string `json:"name"`
 	Description string `json:"description"`
-	Done        bool   `json:"done"`
+	IsDone      bool   `json:"isDone"`
+}
+type mockTaskDoneResponse struct {
+	Tasks []*task `json:"tasks"`
 }
 
 func (t *Task) HandleCreateTask(c echo.Context) error {
@@ -60,17 +67,19 @@ func (t *Task) HandleCreateTask(c echo.Context) error {
 }
 
 func (t *Task) HandleGetTask(c echo.Context) error {
-	var TaskResultList []GetTaskResult
+	var TaskResultList []*GetTaskResult
 
-	TaskResultList = append(TaskResultList, GetTaskResult{
+	TaskResultList = append(TaskResultList, &GetTaskResult{
 		ID:          "testID1",
 		Name:        "testName1",
 		Description: "testDescription1",
+		IsDone:      true,
 	})
-	TaskResultList = append(TaskResultList, GetTaskResult{
+	TaskResultList = append(TaskResultList, &GetTaskResult{
 		ID:          "testID2",
 		Name:        "testName2",
 		Description: "testDescription2",
+		IsDone:      false,
 	})
 	mockRes := &mockGetTaskResponse{
 		Response: TaskResultList,
@@ -80,17 +89,24 @@ func (t *Task) HandleGetTask(c echo.Context) error {
 }
 
 func (t *Task) HandleTaskDone(c echo.Context) error {
-	req := new(TaskDoneRequest)
+	req := new(taskDoneRequest)
 	if err := c.Bind(req); err != nil {
 		log.Println(err)
 		return echo.NewHTTPError(http.StatusBadRequest, "invalid request body")
 	}
-
-	mockRes := &mockTaskDoneResponse{
-		ID:          "doneID",
-		Name:        "doneName",
-		Description: "doneDescription",
-		Done:        true,
+	taskIDs := req.TaskIDs
+	tasks := make([]*task, 0, len(taskIDs))
+	for _, taskID := range taskIDs {
+		task := &task{
+			ID:          taskID.ID,
+			Name:        "doneName",
+			Description: "doneDescription",
+			IsDone:      true,
+		}
+		tasks = append(tasks, task)
+	}
+	mockRes := mockTaskDoneResponse{
+		Tasks: tasks,
 	}
 	return c.JSON(http.StatusOK, mockRes)
 }

--- a/pkg/presentation/controller/task.go
+++ b/pkg/presentation/controller/task.go
@@ -28,11 +28,22 @@ type GetTaskResult struct {
 	ID          string `json:"id"`
 	Name        string `json:"name"`
 	Description string `json:"description"`
-	Done        string `json:"done"`
+	Done        bool   `json:"done"`
 }
 
 type mockGetTaskResponse struct {
 	Response []GetTaskResult
+}
+
+type TaskDoneRequest struct {
+	ID string `json:"id"`
+}
+
+type mockTaskDoneResponse struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Done        bool   `json:"done"`
 }
 
 func (t *Task) HandleCreateTask(c echo.Context) error {
@@ -65,5 +76,21 @@ func (t *Task) HandleGetTask(c echo.Context) error {
 		Response: TaskResultList,
 	}
 
+	return c.JSON(http.StatusOK, mockRes)
+}
+
+func (t *Task) HandleTaskDone(c echo.Context) error {
+	req := new(TaskDoneRequest)
+	if err := c.Bind(req); err != nil {
+		log.Println(err)
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid request body")
+	}
+
+	mockRes := &mockTaskDoneResponse{
+		ID:          "doneID",
+		Name:        "doneName",
+		Description: "doneDescription",
+		Done:        true,
+	}
 	return c.JSON(http.StatusOK, mockRes)
 }

--- a/pkg/presentation/controller/task.go
+++ b/pkg/presentation/controller/task.go
@@ -24,6 +24,17 @@ type mockCreateTaskResponse struct {
 	Description string `json:"description"`
 }
 
+type GetTaskResult struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Done        string `json:"done"`
+}
+
+type mockGetTaskResponse struct {
+	Response []GetTaskResult
+}
+
 func (t *Task) HandleCreateTask(c echo.Context) error {
 	req := new(CreateTaskRequest)
 	if err := c.Bind(req); err != nil {
@@ -34,5 +45,25 @@ func (t *Task) HandleCreateTask(c echo.Context) error {
 		Name:        req.Name,
 		Description: req.Description,
 	}
+	return c.JSON(http.StatusOK, mockRes)
+}
+
+func (t *Task) HandleGetTask(c echo.Context) error {
+	var TaskResultList []GetTaskResult
+
+	TaskResultList = append(TaskResultList, GetTaskResult{
+		ID:          "testID1",
+		Name:        "testName1",
+		Description: "testDescription1",
+	})
+	TaskResultList = append(TaskResultList, GetTaskResult{
+		ID:          "testID2",
+		Name:        "testName2",
+		Description: "testDescription2",
+	})
+	mockRes := &mockGetTaskResponse{
+		Response: TaskResultList,
+	}
+
 	return c.JSON(http.StatusOK, mockRes)
 }

--- a/pkg/presentation/controller/task.go
+++ b/pkg/presentation/controller/task.go
@@ -14,33 +14,8 @@ func NewTask() *Task {
 	return &Task{}
 }
 
-type CreateTaskRequest struct {
-	Name        string `json:"name"`
-	Description string `json:"description"`
-}
-
-type mockCreateTaskResponse struct {
-	Name        string `json:"name"`
-	Description string `json:"description"`
-}
-
-type GetTaskResult struct {
-	ID          string `json:"id"`
-	Name        string `json:"name"`
-	Description string `json:"description"`
-	IsDone      bool   `json:"isDone"`
-}
-
-type mockGetTaskResponse struct {
-	Response []*GetTaskResult
-}
-
 type taskID struct {
 	ID string `json:"id"`
-}
-
-type taskDoneRequest struct {
-	TaskIDs []*taskID `json:"taskIDs"`
 }
 
 type task struct {
@@ -49,40 +24,61 @@ type task struct {
 	Description string `json:"description"`
 	IsDone      bool   `json:"isDone"`
 }
+
+type createTaskRequest struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
+type mockCreateTaskResponse struct {
+	task
+}
+
+type mockGetTaskResponse struct {
+	Tasks []*task `json:"tasks"`
+}
+
+type taskDoneRequest struct {
+	TaskIDs []*taskID `json:"taskIDs"`
+}
+
 type mockTaskDoneResponse struct {
 	Tasks []*task `json:"tasks"`
 }
 
 func (t *Task) HandleCreateTask(c echo.Context) error {
-	req := new(CreateTaskRequest)
+	req := new(createTaskRequest)
 	if err := c.Bind(req); err != nil {
 		log.Println(err)
 		return echo.NewHTTPError(http.StatusBadRequest, "invalid request body")
 	}
 	mockRes := &mockCreateTaskResponse{
-		Name:        req.Name,
-		Description: req.Description,
+		task{
+			ID:          "id",
+			Name:        req.Name,
+			Description: req.Description,
+			IsDone:      false,
+		},
 	}
 	return c.JSON(http.StatusOK, mockRes)
 }
 
 func (t *Task) HandleGetTask(c echo.Context) error {
-	var TaskResultList []*GetTaskResult
-
-	TaskResultList = append(TaskResultList, &GetTaskResult{
+	var tasks []*task
+	tasks = append(tasks, &task{
 		ID:          "testID1",
 		Name:        "testName1",
 		Description: "testDescription1",
 		IsDone:      true,
 	})
-	TaskResultList = append(TaskResultList, &GetTaskResult{
+	tasks = append(tasks, &task{
 		ID:          "testID2",
 		Name:        "testName2",
 		Description: "testDescription2",
 		IsDone:      false,
 	})
 	mockRes := &mockGetTaskResponse{
-		Response: TaskResultList,
+		Tasks: tasks,
 	}
 
 	return c.JSON(http.StatusOK, mockRes)

--- a/pkg/presentation/router.go
+++ b/pkg/presentation/router.go
@@ -17,5 +17,6 @@ func NewEcho() *echo.Echo {
 	t := controller.NewTask()
 	e.POST("/tasks", t.HandleCreateTask)
 	e.GET("/tasks", t.HandleGetTask)
+	e.POST("/tasks/done", t.HandleTaskDone)
 	return e
 }

--- a/pkg/presentation/router.go
+++ b/pkg/presentation/router.go
@@ -16,5 +16,6 @@ func NewEcho() *echo.Echo {
 
 	t := controller.NewTask()
 	e.POST("/tasks", t.HandleCreateTask)
+	e.GET("/tasks", t.HandleGetTask)
 	return e
 }


### PR DESCRIPTION
```
GET /tasks
POST /tasks/done
```
のmockAPIを作成しました．
- GET /tasksに対して，2つのtestデータが入った配列をjsonで返します．
- POST /tasks/doneに対して，testデータをjsonで返します．

- mockAPIが正しく実装できているか，ご確認よろしくお願いいたしますmm